### PR TITLE
Custom download links

### DIFF
--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -8,7 +8,7 @@ class Package < ActiveRecord::Base
   pg_search_scope :fulltext_search,
     against: [:name, :github_repo, :description, :readme_markdown]
   acts_as_taggable
-  attr_accessible :github_repo, :name, :description, :homepage, :readme_markdown, :tag_list
+  attr_accessible :github_repo, :name, :description, :homepage, :readme_markdown, :tag_list, :download_url
 
   validates :name, 
     format: /^[a-z0-9_\.-]+$/i,
@@ -54,7 +54,8 @@ class Package < ActiveRecord::Base
   end
 
   def download_url
-    "#{github_url}/archive/master.zip"
+    url = read_attribute(:download_url)
+    (url && !url.empty? && url) || (!"#{github_repo}".empty? && "#{github_url}/archive/master.zip")
   end
 
   def readme_html

--- a/app/models/permitted_params.rb
+++ b/app/models/permitted_params.rb
@@ -10,7 +10,8 @@ class PermittedParams < Struct.new(:params, :user)
       :description,
       :homepage,
       :tag_list,
-      :readme_markdown
+      :readme_markdown,
+      :download_url
     ]
   end
   

--- a/app/views/packages/_form.html.erb
+++ b/app/views/packages/_form.html.erb
@@ -26,6 +26,12 @@
     </div>
   </div>
   <div class="control-group">
+    <%= f.label :download_url, class: "control-label" %>
+    <div class="controls">
+      <%= f.text_field :download_url, class: "input-xlarge", placeholder: "Download link for module" %>
+    </div>
+  </div>
+  <div class="control-group">
     <%= f.label :homepage, class: "control-label" %>
     <div class="controls">
       <%= f.text_field :homepage, class: "input-xlarge", placeholder: "http://awesome-module.org" %>

--- a/db/migrate/20131027014349_add_download_url_to_packages.rb
+++ b/db/migrate/20131027014349_add_download_url_to_packages.rb
@@ -1,0 +1,5 @@
+class AddDownloadUrlToPackages < ActiveRecord::Migration
+  def change
+    add_column :packages, :download_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20121210002447) do
+ActiveRecord::Schema.define(:version => 20131027014349) do
 
   create_table "blog_posts", :force => true do |t|
     t.string   "title"
@@ -35,6 +35,7 @@ ActiveRecord::Schema.define(:version => 20121210002447) do
     t.integer  "owner_id"
     t.integer  "submitter_id"
     t.integer  "uses_count",      :default => 0
+    t.string   "download_url"
   end
 
   create_table "taggings", :force => true do |t|


### PR DESCRIPTION
In many cases, the github repository contains unbuilt sources (while we might store the built libraries in gh-pages or something)

It would be nice to be able to customize the way the `download` link works, so that it can point to gh-pages or a separate webserver or something.
